### PR TITLE
Render no compila por no encontrar el modelo usuarios. Se cambió eso.

### DIFF
--- a/src/controladores/usuario.ts
+++ b/src/controladores/usuario.ts
@@ -5,9 +5,7 @@ var path = require('path');
 var bcrypt = require('bcrypt-nodejs');
 
 // import Usuario from '../../src/modelos/usuario';
-// var Usuario = require('../modelos/usuario')
-
-import Usuario from '../../src/modelos/usuario';
+var Usuario = require('../modelos/usuario')  //('../modelos/usuario')
 var Persona = require('../modelos/persona');
 
 var jwt = require('../servicios/jwt');


### PR DESCRIPTION
Probando si cambiando la forma de acceso a la clase, como estaba antes, funciona.
Ya que cuando crea el "dist" hay un directorio menos, ya que toma directamente todo lo del "src"